### PR TITLE
Relax Version Constraints for @mermaid-js/mermaid-cli in Peer Dependencies

### DIFF
--- a/remark-mermaid/build.js
+++ b/remark-mermaid/build.js
@@ -5,5 +5,6 @@ build({
   outbase: "./src",
   outdir: "./dist",
   platform: "node",
+  target: "es2021",
   external: [],
 });

--- a/remark-mermaid/package.json
+++ b/remark-mermaid/package.json
@@ -35,6 +35,6 @@
     "unified": "^10.1.2"
   },
   "peerDependencies": {
-    "@mermaid-js/mermaid-cli": "9.3.0"
+    "@mermaid-js/mermaid-cli": "^11.0.0 || ^10.0.0 || ^9.0.0"
   }
 }


### PR DESCRIPTION
## Purpose of This Pull Request

This Pull Request aims to make the version specification of @mermaid-js/mermaid-cli in peer dependencies more flexible.

## Reason for This Change

The ws package, which is a dependency of @mermaid-js/mermaid-cli, currently triggers a security alert with Severity: high.

For reference, see:
https://github.com/advisories/GHSA-3h5v-q93c-6h6q

```
 @southball/remark-mermaid@0.5.0
  └─┬ @mermaid-js/mermaid-cli@9.3.0
    └─┬ puppeteer@19.11.1
      └─┬ puppeteer-core@19.11.1
        └── ws@8.13.0
```

The latest version of @mermaid-js/mermaid-cli is 11.4.2.
While we could specify this exact version (e.g., "@mermaid-js/mermaid-cli": "11.4.2"), doing so would force other packages or projects to adopt this version, potentially causing compatibility issues.

To address this, this PR modifies the version range to "^11.0.0 || ^10.0.0 || ^9.0.0", allowing us to maintain compatibility with existing setups while enabling the use of the latest version, @mermaid-js/mermaid-cli@11.4.2.

## Other Changes

In my local environment, the build process failed because the target option was not specified in the esbuild configuration. To resolve this, I added the appropriate target option.